### PR TITLE
feat/swiftformat

### DIFF
--- a/Casks/swiftformat-al.rb
+++ b/Casks/swiftformat-al.rb
@@ -1,10 +1,11 @@
 cask "swiftformat-al" do
   version "0.1.0"
+  sha256 "0b953f35b253f88b2934dff820f75a95450b90c394188b82fbf7245b51c7ae58"
+  
+  url "https://github.com/AppLovin/homebrew-Mobile-Tools/releases/download/swiftformat-al-v#{version}/SwiftFormat-for-Xcode.zip"
   name "swiftformat-al"
   desc "This is a version of SwiftFormat for Xcode, an editor extension forked from https://github.com/nicklockwood/SwiftFormat"
-  url "https://github.com/AppLovin/homebrew-Mobile-Tools/releases/download/swiftformat-al-v0.1.0/SwiftFormat-for-Xcode.zip"
- 
-  sha256 "0b953f35b253f88b2934dff820f75a95450b90c394188b82fbf7245b51c7ae58"
-
+  homepage "https://github.com/AppLovin/homebrew-Mobile-Tools"
+  
   app "SwiftFormat for Xcode.app"
 end

--- a/Casks/swiftformat-al.rb
+++ b/Casks/swiftformat-al.rb
@@ -1,12 +1,10 @@
 cask "swiftformat-al" do
-
   version "0.1.0"
-  sha256 "f6ca221ada6eae684d2ce397c72900bbe7eb9f3674d8d33eff2c56d4df4f6810"
-
-  url "https://github.com/AppLovin/homebrew-Mobile-Tools/releases/download/swiftformat-al-v0.1.0/SwiftFormat-for-Xcode.zip"
   name "swiftformat-al"
   desc "This is a version of SwiftFormat for Xcode, an editor extension forked from https://github.com/nicklockwood/SwiftFormat"
-  homepage "https://github.com/AppLovin/homebrew-Mobile-Tools"
+  url "https://github.com/AppLovin/homebrew-Mobile-Tools/releases/download/swiftformat-al-v0.1.0/SwiftFormat-for-Xcode.zip"
+ 
+  sha256 "0b953f35b253f88b2934dff820f75a95450b90c394188b82fbf7245b51c7ae58"
 
   app "SwiftFormat for Xcode.app"
 end

--- a/Casks/swiftformat-al.rb
+++ b/Casks/swiftformat-al.rb
@@ -1,5 +1,5 @@
 cask "swiftformat-al" do
-  version "0.1.0"
+  version "0.52.8"
   sha256 "0b953f35b253f88b2934dff820f75a95450b90c394188b82fbf7245b51c7ae58"
   
   url "https://github.com/AppLovin/homebrew-Mobile-Tools/releases/download/swiftformat-al-v#{version}/SwiftFormat-for-Xcode.zip"

--- a/Casks/swiftformat-al.rb
+++ b/Casks/swiftformat-al.rb
@@ -1,0 +1,12 @@
+cask "swiftformat-al" do
+
+  version "0.1.0"
+  sha256 "f6ca221ada6eae684d2ce397c72900bbe7eb9f3674d8d33eff2c56d4df4f6810"
+
+  url "https://github.com/AppLovin/homebrew-Mobile-Tools/releases/download/swiftformat-al-v0.1.0/SwiftFormat-for-Xcode.zip"
+  name "swiftformat-al"
+  desc "This is a version of SwiftFormat for Xcode, an editor extension forked from https://github.com/nicklockwood/SwiftFormat"
+  homepage "https://github.com/AppLovin/homebrew-Mobile-Tools"
+
+  app "SwiftFormat for Xcode.app"
+end


### PR DESCRIPTION
https://app.asana.com/0/573104092700345/1205720904897684/f

Adds ability for devs to install SwiftFormat cask via homebrew:
Example usage: `brew install --cask swiftformat-al`